### PR TITLE
Adds support for "POST"  matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ This will match http://localhost:3012/news/007 as well as http://localhost:3012/
 > responseCode: 200,  
 > responseBody: 'whatever you want' }  
 
+##### Fake-server supports "POST" calls and uses payload for matching.
+
+NOTE: payload matching does not support RegEx yet. Here is an example that matches POST requests to /news with id: 1
+
+> { route: '/news'
+>   payload {
+>     id: 1
+>   },
+>   responseCode: 200,
+>   responseBody: 'yay! it matches'
+> }
+
+
 ##### Response can be a file. In this case, fake-server will respond with the output of that file.
 
 The following configuration example will return the output of ./mock_data/sample.json *(notice the parameter is called responseData instead of responseBody)*
@@ -110,9 +123,8 @@ To avoid the need to restart fake-server in order to clear the configuration, we
 
 
 ### Limitations
-- Fake-server matches only URI, it won't work with `POST` body data (although you can `POST` to a fake URI)
 - There are two reserved endpoints: POST '/add' and  `DELETE` '/flush'. These cannot be used by your application.
-- There is still no support for custom headers in response or for headers in general.  
+- There is still no support for request headers validation. All you can do is configure the response headers. 
 
 
 ### Get in touch:  

--- a/controller.js
+++ b/controller.js
@@ -43,7 +43,7 @@ var controller = {
             res.end();
         }
 
-        var bestMatch = controller.fakeResponse.match(req.url);
+        var bestMatch = controller.fakeResponse.match(req.url, req.body);
 
         if (bestMatch) {
             var headers = {

--- a/fakeresponse.js
+++ b/fakeresponse.js
@@ -50,17 +50,15 @@ var FakeResponse = {
     },
 
     /* Filters all items that match the URL and then tries to check if there is a specific behavior for the Nth call on the same endpoint */
-    match: function (uri) {
+    match: function (uri, payload) {
         return FakeResponse._items.filter(function (item) {
             var matches = uri.match(new RegExp(item.route));
 
             if (matches !== null) {
                 item.numCalls += 1;
+                if(item.payload && !FakeResponse.matchPayload(item, payload)) return false; 
                 if (item.at) {
-                    if (item.numCalls === item.at) {
-                        return true;
-                    }
-                    return false;
+                    return (item.numCalls === item.at); 
                 }
                 return true;
             }
@@ -70,6 +68,16 @@ var FakeResponse = {
                 return match;
             }
         }, 0);
+    },
+
+    matchPayload: function(item, payload) {
+        if (typeof(payload) !== "object" || typeof(item.payload) !== "object") return false;
+        for (var ppty in item.payload) {
+            if (!item.payload.hasOwnProperty(ppty) || !payload.hasOwnProperty(ppty)) return false;
+            if (item.payload[ppty] !== payload[ppty]) return false;
+        }
+        return true;
+
     }
 };
 

--- a/test/controller.js
+++ b/test/controller.js
@@ -151,8 +151,6 @@ describe('Integration tests', function () {
 
         controller.add(req, res, function () {});
 
-        
-
         controller.match({
             url: '/delayed',
         }, res, next);
@@ -166,12 +164,11 @@ describe('Integration tests', function () {
         assert.isTrue(next.calledOnce);
 
         clock.restore();
-
         done();
     });
 
 
-    it('Should Default to header application/json', function (done) {
+    it('Should Default to header application/json', function () {
         var next = sinon.stub(),
 
             obj = {
@@ -184,7 +181,6 @@ describe('Integration tests', function () {
                     route: '/abc',
                 }
             },
-            
             res = {
                 send: sinon.stub(),
                 write: sinon.stub(),
@@ -202,7 +198,44 @@ describe('Integration tests', function () {
         assert.isTrue(res.writeHead.calledWithExactly(200, {'Content-Type': 'application/json', 'Content-Length': 2}));
         assert.isTrue(res.write.calledWithExactly('OK'));
         assert.isTrue(res.end.calledOnce);
+    });
 
-        done();
+    it('should work with POST requests', function() {
+        var next = sinon.stub(),
+            obj = {
+                route: '/abc',
+                payload: {
+                    'name': 'something',
+                    'id': 1
+                },
+                responseCode: 200,
+                responseBody: 'OK'
+            },
+            req = {
+                url: '/abc',
+                params: {
+                    route: '/abc',
+                },
+                body: {
+                    'id': 1,
+                    'name': 'something'
+                }
+            },
+            res = {
+                send: sinon.stub(),
+                write: sinon.stub(),
+                writeHead: sinon.stub(),
+                end: sinon.stub()
+            };
+
+        controller.fakeResponse.add(obj);
+
+        controller.match(req, res, next);
+
+        assert.isTrue(res.write.calledWithExactly('OK'));
+        assert.isTrue(res.end.calledOnce);
+
+
+
     });
 });

--- a/test/fakeresponse.js
+++ b/test/fakeresponse.js
@@ -127,4 +127,44 @@ describe('FakeResponse model tests', function () {
             assert.ok(false,'should not throw exceptions on a controlled test environemnt');
         });
     });
+
+    /* POST request tests */
+    it('should use payload to match against for POST requests', function() {
+        model.add({
+            route: '/match/me',
+            payload: {
+                'id': 1
+            },
+            responseCode: 200,
+            responseBody: 'weba',
+        });
+        /*even though "uri"  is the same, we are only matching if payload contains id:1 */
+        var response = model.match('/match/me');
+        assert.equal(0, response);
+     });
+
+     it('should use payload to match against for POST requests', function() {
+        var obj = {};
+        model.add({
+            route: '/match/me',
+            payload: {
+                'id': 1
+            },
+            responseCode: 200,
+            responseBody: 'weba',
+        });
+        model.add({
+            route: '/match/me',
+            payload: {
+                'id': 2
+            },
+            responseCode: 403,
+            responseBody: 'buuu'
+        });
+        /*even though "uri"  is the same, we are only matching if payload contains id:1 */
+        var response = model.match('/match/me', { id: 1 });
+        assert.deepEqual(response.responseBody, 'weba');
+        assert.deepEqual(response.responseCode, 200);
+     });
+
 });


### PR DESCRIPTION
added a "payload"  option to the route configuration. Every item in the "payload"  is required to match, but the original request may have additional fields.
## 

bigo
