### PR TITLE
Support inline JSON in the route configs

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -39,6 +39,14 @@ var controller = {
     match: function (req, res, next) {
         
         function send (statusCode, responseHeaders, responseBody) {
+            if (typeof responseBody === "object") {
+                try {
+                    responseBody = JSON.stringify(responseBody);
+                } catch (e) {
+                    responseBody = "Unable to serialize responseBody";
+                    res.statusCode = 500;
+                }
+            }
             responseHeaders['Content-Length'] = Buffer.byteLength(responseBody);
             res.writeHead(statusCode, responseHeaders);
             res.write(responseBody);


### PR DESCRIPTION
Before this commit, if you specified `responseBody` as an object (rather than string) in a `mock-config`, it would get parsed as a JS object, and `res.write` does not accept objects.
